### PR TITLE
added .sav option

### DIFF
--- a/src/MainUI.cpp
+++ b/src/MainUI.cpp
@@ -18,7 +18,7 @@ MainUI::MainUI() : BaseUI(nullptr)
 	windowOpacity = 0.9f;
 
 	fileDialog.SetTitle("Open a Banjo-Kazooie save file");
-	fileDialog.SetTypeFilters({ ".eep", ".*" });
+	fileDialog.SetTypeFilters({ ".eep", ".sav", ".*" });
 
 	LoadConfig();
 }


### PR DESCRIPTION
some some flash carts and emulators (like summercart64) use .sav instead of .eep whilst still being the same as it (i tested and it does just edit them like normal)